### PR TITLE
Revision 4 - The beginning of the end

### DIFF
--- a/Story.md
+++ b/Story.md
@@ -1,3 +1,3 @@
-# Hacktoberfest
+# Shitoberfest
 
-Hacktoberfest is a great way for new developers to attempt to contribute to Open-Source projects of all sizes. Participants who make four low-hanging pull requests win a cool T-shirt from Digital Ocean, unless maintainers opt out of the spam. Quantity is necessary, quality varies.
+Shitoberfest is a great way for T-shirt seekers to spam Open-Source maintainers of popular projects. Participants who make four self-approved pull requests win a shameful T-shirt ad from Digital Ocean (or make them plant a tree) at the expense of the community's time and attention, while those who make useful PRs don't get approved in time and get nothing. Quantity is annoying, quality is low.


### PR DESCRIPTION
The spam became untenable as a viral flood of users who didn't know how to code overwhelmed popular projects. As maintainers' voices converged into \#Shitoberfest, it became clear that the program was doing more harm than good for the open-source community. In an attempt to save face, Digital Ocean decided to make the event opt-in to maintainers. Unfortunately, this killed most legitimate contributions too. Depending on the project, maintainers took weeks to review and merge PRs. Without approval by the deadline, a PR that took a week or more to develop could be useless to the challenge--not worth the risk! Not to mention, the number of participating repositories was small. No longer could I search for niche projects and submit small fixes as a reliable backup plan. The owner would have to both approve and opt-in the PR in time. Ultimately, you'd have to develop a lot more than 4 PRs to complete the challenge legitimately, and that completely undermines the "quantity is fun, quality is key" mantra.

So, I suspect many folks who completed the challenge did it illegitimately by making self-approved PRs to their own repos or to projects designed specifically for Hacktoberfest.

With the ire and stigma Hacktoberfest has elicited from maintainers, this year's shirt is seen by many as a badge of shame. 

Digital Ocean's marketing campaign, which was started with the best intentions, hasn't lived up to its aspirations. If it continues to lay this annual spam burden on the Open-Source commons, it will not go well for anybody.

## Future directions

I invite Digital Ocean or maintainers to submit their own PRs to this project to change this narrative for the future. I suggest committing to the "quality is key virtue" by requiring one single good PR and extending the approval deadline into November, but that's not the only way forward.